### PR TITLE
Add rust toolchain to shell.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,13 +160,8 @@ Shows time in configured format and refreshes every second or minute.
 You need `rustup` with nightly toolchain, rustfmt, clippy and `lib{dbus,gdk-pixbuf,notify,x11}-dev`. I recommend the
 installation of racer.
 
-If your are using [nix](https://nixos.org/nix) you can use `shell.nix` for all dependencies except the `rustup`
-toolchain and components:
+If your are using [nix](https://nixos.org/nix) you can use `shell.nix` for all dependencies, including the nightly rust compiler:
 
 ```sh
 $ nix-shell
-[nix-shell]$ rustup install nightly
-[nix-shell]$ rustup default nightly
-[nix-shell]$ rustup component add clippy-preview
-[nix-shell]$ rustup component add rustfmt-preview
 ```

--- a/shell.nix
+++ b/shell.nix
@@ -33,6 +33,11 @@ stdenv.mkDerivation {
 
   shellHook = ''
     rustup install nightly
+    # store old default toolchain
+    defaulttoolchain=$(rustup toolchain list | awk '$2 == "(default)" { print $1; }')
+    if [ $defaulttoolchain ]; then # if $defaulttoolchain contains anything
+      trap "rustup default $defaulttoolchain" EXIT # restore the old toolchain
+    fi
     rustup default nightly
     rustup component add clippy-preview
     rustup component add rustfmt-preview

--- a/shell.nix
+++ b/shell.nix
@@ -30,4 +30,11 @@ stdenv.mkDerivation {
   ];
 
   # RUST_BACKTRACE = 1;
+
+  shellHook = ''
+    rustup install nightly
+    rustup default nightly
+    rustup component add clippy-preview
+    rustup component add rustfmt-preview
+  '';
 }


### PR DESCRIPTION
This technically runs it every time you enter the environment, however it does nothing for the most part.

It'll also store the old default toolchain and restore it when you exit the nix-shell. One problem with this is that if you exit by closing the terminal instead of running `exit`, the old toolchain will not be restored.