### PR TITLE
Restoring previous behaviour of multiple batteries

### DIFF
--- a/src/features/battery/data.rs
+++ b/src/features/battery/data.rs
@@ -65,14 +65,12 @@ impl Data {
                 self.push_time(&mut list, time_to_empty);
                 list
             },
-            Battery::Unknown {
-                percentage
-            } => {
+            Battery::Unknown { percentage } => {
                 let capacity = get_raw_percent(percentage);
                 let mut list = vec![];
                 self.push_capacity(&mut list, capacity);
                 list
-            }
+            },
             Battery::Empty => {
                 let mut list = vec![];
                 self.push_capacity(&mut list, 0.);

--- a/src/features/battery/data.rs
+++ b/src/features/battery/data.rs
@@ -65,6 +65,14 @@ impl Data {
                 self.push_time(&mut list, time_to_empty);
                 list
             },
+            Battery::Unknown {
+                percentage
+            } => {
+                let capacity = get_raw_percent(percentage);
+                let mut list = vec![];
+                self.push_capacity(&mut list, capacity);
+                list
+            }
             Battery::Empty => {
                 let mut list = vec![];
                 self.push_capacity(&mut list, 0.);

--- a/src/wrapper/battery.rs
+++ b/src/wrapper/battery.rs
@@ -43,18 +43,18 @@ pub(crate) fn all_batteries() -> Result<Vec<Battery>> {
                 }),
                 battery::State::Empty => Some(Battery::Empty),
                 battery::State::Full => Some(Battery::Full),
-                battery::State::Unknown => Some(Battery::Unknown { 
+                battery::State::Unknown => Some(Battery::Unknown {
                     // Unknown can mean either controller returned unknown,
                     // or not able to retrieve state due to some error.
                     // Nevertheless, it should be possible to get the state of
                     // charge.
-                    percentage: battery.state_of_charge()
+                    percentage: battery.state_of_charge(),
                 }),
                 _ => {
                     // battery::State is non-exhaustive so we should handle this case
                     warn!("An hunandled state was reported when reading battery data");
                     None
-                }
+                },
             },
             Err(err) => {
                 warn!("An error occurred reading battery data: {}", err);


### PR DESCRIPTION
This commit try to restore the old behaviour when multiples batteries
are detected.

On some machines, only the currently "active" battery can be fully
detected and manipulated. Others fall in the Unknown state. This state
is now handled.

This solve #11 