### PR TITLE
Implements xkb keymap feature.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
             ${{ matrix.rust }}-cargo-build-target-
 
       - name: Install build dependencies
-        run: sudo apt-get install libdbus-1-dev libgdk-pixbuf2.0-dev libglib2.0-dev libnotify-dev
+        run: sudo apt-get install libdbus-1-dev libgdk-pixbuf2.0-dev libglib2.0-dev libnotify-dev libxcb-xkb-dev
 
       - name: Install tarpaulin
         if: matrix.rust == 'nightly'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,7 @@ dependencies = [
  "simplelog",
  "uom",
  "x11",
+ "xcb",
 ]
 
 [[package]]
@@ -907,6 +908,16 @@ checksum = "77ecd092546cb16f25783a5451538e73afc8d32e242648d54f4ae5459ba1e773"
 dependencies = [
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "xcb"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e917a3f24142e9ff8be2414e36c649d47d6cc2ba81f16201cdef96e533e02de"
+dependencies = [
+ "libc",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde = "1.0.118"
 serde_derive = "1.0.118"
 simplelog = "0.9.0"
 uom = { version = "0.30.0", features = ["autoconvert", "f32", "si"] }
+xcb = { version = "0.8", features = ["xkb"] }
 
 [dependencies.ctrlc]
 features = ["termination"]

--- a/README.md
+++ b/README.md
@@ -158,9 +158,20 @@ Shows time in configured format and refreshes every second or minute.
 | `format`         | `"%Y-%m-%d %H:%M"`  | Time format of [chrono crate](https://github.com/chronotope/chrono). |
 | `update_seconds` | `false`             | Whether to update time feature every second or minute, automatically set by parsing `format`. |
 
+### Feature: Keymap
+
+Shows current keyboard layout. Updates get triggered by listening on xkb state notify events.
+
+#### Configuration options
+
+| name       | default                       | description                     |
+| ---------- | ----------------------------- | ------------------------------- |
+| `flags`    | `[]`                          | List of flags representing keyboard layouts.     |
+| `template` | `"{FLAG}"`                    | Text representation. Placeholder surrounded by curly braces is `{FLAG}`. |
+
 ## Contributing
 
-You need `rustup` with nightly toolchain, rustfmt, clippy and `lib{dbus,gdk-pixbuf,notify,x11}-dev`. I recommend the
+You need `rustup` with stable toolchain, rustfmt, clippy and `lib{dbus,gdk-pixbuf,notify,x11}-dev`. I recommend the
 installation of racer.
 
 If your are using [nix](https://nixos.org/nix) you can use `shell.nix` for all dependencies except the `rustup`

--- a/default.nix
+++ b/default.nix
@@ -25,7 +25,7 @@ naersk.buildPackage {
     ./.;
 
   nativeBuildInputs = [ makeWrapper pkgconfig ];
-  buildInputs = [ dbus gdk_pixbuf libnotify xorg.libX11 ];
+  buildInputs = [ dbus gdk_pixbuf libnotify xorg.libX11 xorg.libxcb python3 ];
 
   postInstall = ''
     # run only when building the final package

--- a/examples/default-settings/defaults.hjson
+++ b/examples/default-settings/defaults.hjson
@@ -41,4 +41,8 @@
     format: %Y-%m-%d %H:%M
     update_seconds: false
   }
+  keymap: {
+    template: "{FLAG}"
+    icons: []
+  }
 }

--- a/examples/default-settings/defaults.json
+++ b/examples/default-settings/defaults.json
@@ -40,5 +40,9 @@
   "time": {
     "format": "%Y-%m-%d %H:%M",
     "update_seconds": false
+  },
+  "keymap": {
+    "template": "{FLAG}",
+    "flags": []
   }
 }

--- a/examples/default-settings/defaults.toml
+++ b/examples/default-settings/defaults.toml
@@ -34,3 +34,7 @@ template = "{IPv4} · {IPv6} · {ESSID}"
 [time]
 format = "%Y-%m-%d %H:%M"
 update_seconds = false
+
+[keymap]
+template = "{FLAG}"
+flags = []

--- a/examples/default-settings/defaults.yml
+++ b/examples/default-settings/defaults.yml
@@ -34,3 +34,7 @@ network:
 time:
   format: "%Y-%m-%d %H:%M"
   update_seconds: false
+
+keymap:
+  template: "{FLAG}"
+  flags: []

--- a/examples/icon-settings/nerd-font.toml
+++ b/examples/icon-settings/nerd-font.toml
@@ -14,3 +14,7 @@ charging = ""
 discharging = ""
 no_battery = ""
 icons = ["", "", "", "", "", "", "", "", "", "", ""]
+
+[keymap]
+template = "{FLAG}"
+flags = ["󾓦", "󾓬"]

--- a/shell.nix
+++ b/shell.nix
@@ -12,6 +12,7 @@ pkgs.mkShell {
     libnotify
     pkgconfig
     xorg.libX11
+    xcb-xkb
 
     # run-time dependencies
     alsaUtils

--- a/src/features.rs
+++ b/src/features.rs
@@ -2,6 +2,7 @@ pub(super) mod audio;
 pub(super) mod backlight;
 pub(super) mod battery;
 pub(super) mod cpu_load;
+pub(super) mod keymap;
 pub(super) mod network;
 pub(super) mod time;
 
@@ -38,5 +39,6 @@ pub(super) fn create_feature(
         cpu_load,
         network,
         time,
+        keymap,
     )
 }

--- a/src/features/keymap.rs
+++ b/src/features/keymap.rs
@@ -1,0 +1,31 @@
+mod config;
+mod data;
+mod notifier;
+mod updater;
+
+use crate::communication;
+use crate::error::*;
+use crate::feature;
+use crate::wrapper::channel;
+
+pub(crate) use self::config::ConfigEntry;
+pub(self) use self::config::RenderConfig;
+pub(self) use self::data::Data;
+pub(self) use self::notifier::Notifier;
+pub(self) use self::updater::Updater;
+
+pub(super) const FEATURE_NAME: &str = "keymap";
+
+pub(super) fn create(
+    id: usize,
+    sender: &channel::Sender<communication::Message>,
+    settings: &ConfigEntry,
+) -> Result<Box<dyn feature::Feature>> {
+    let data = Data::new(settings.render.clone());
+
+    Ok(Box::new(feature::Composer::new(
+        FEATURE_NAME,
+        Notifier::new(id, sender.clone()),
+        Updater::new(data),
+    )))
+}

--- a/src/features/keymap/config.rs
+++ b/src/features/keymap/config.rs
@@ -1,0 +1,57 @@
+use super::FEATURE_NAME;
+use crate::error::*;
+use crate::settings::ConfigType;
+use crate::wrapper::config;
+use crate::wrapper::config::Value;
+use serde_derive::*;
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct RenderConfig {
+    pub(super) flags: Vec<String>,
+    pub(super) template: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct ConfigEntry {
+    #[serde(flatten)]
+    pub(super) render: RenderConfig,
+}
+
+impl ConfigType for ConfigEntry {
+    fn set_default(config: &mut config::Config) -> Result<()> {
+        config.set_default(
+            FEATURE_NAME,
+            map!(
+                "flags"    => Vec::<String>::new(),
+                "template" => "{FLAG}",
+            ),
+        )
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "mocking")]
+mod tests {
+    use super::*;
+    use crate::test_utils::config::test_set_default_err;
+    use crate::test_utils::config::test_set_default_ok;
+    use std::collections::HashMap;
+
+    #[test]
+    fn config_type_set_default_when_ok() {
+        test_set_default_ok::<ConfigEntry>("keymap", default_map);
+    }
+
+    #[test]
+    fn config_type_set_default_when_err() {
+        test_set_default_err::<ConfigEntry>("keymap", default_map);
+    }
+
+    fn default_map() -> HashMap<String, Value> {
+        let mut map = HashMap::new();
+        map.insert("flags".to_owned(), Vec::<String>::new().into());
+        map.insert("template".to_owned(), "{FLAG}".into());
+
+        map
+    }
+}

--- a/src/features/keymap/data.rs
+++ b/src/features/keymap/data.rs
@@ -1,0 +1,84 @@
+use super::RenderConfig;
+use crate::feature::Renderable;
+
+#[derive(Debug)]
+pub(super) struct Data {
+    cache: String,
+    config: RenderConfig,
+}
+
+impl Data {
+    #[allow(clippy::missing_const_for_fn)]
+    pub(super) fn new(config: RenderConfig) -> Self {
+        Self {
+            cache: String::new(),
+            config,
+        }
+    }
+
+    pub(super) fn update(&mut self, value: u8) {
+        if self.config.flags.len() > value as usize {
+            self.cache = self
+                .config
+                .template
+                .replace("{FLAG}", &self.config.flags[value as usize]);
+        } else {
+            panic!(
+                "There's not enough flags in the configuration to display group {}",
+                value
+            );
+        }
+    }
+}
+
+impl Renderable for Data {
+    fn render(&self) -> &str {
+        &self.cache
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hamcrest2::assert_that;
+    use hamcrest2::prelude::*;
+    #[cfg(feature = "mocking")]
+    use mocktopus::mocking::*;
+
+    #[test]
+    fn render_with_default() {
+        let config = RenderConfig {
+            flags: vec![],
+            template: "TEMPLATE".to_owned(),
+        };
+
+        let object = Data::new(config);
+
+        assert_that!(object.render(), is(equal_to("")));
+    }
+
+    #[test]
+    #[should_panic]
+    fn render_with_value_not_enough_flags() {
+        let config = RenderConfig {
+            flags: vec!["us".to_owned(), "ru".to_owned()],
+            template: "TEMPLATE {FLAG}".to_owned(),
+        };
+
+        let mut object = Data::new(config);
+        object.update(3);
+    }
+
+    #[test]
+    fn render_with_value() {
+        let config = RenderConfig {
+            flags: vec!["us".to_owned(), "ru".to_owned()],
+            template: "TEMPLATE {FLAG}".to_owned(),
+        };
+
+        let mut object = Data::new(config);
+        object.update(1);
+
+        assert_that!(object.render(), is(equal_to("TEMPLATE ru")));
+    }
+}

--- a/src/features/keymap/notifier.rs
+++ b/src/features/keymap/notifier.rs
@@ -1,0 +1,67 @@
+use crate::communication;
+use crate::error::*;
+use crate::wrapper::channel;
+use crate::wrapper::thread;
+use xcb;
+use xcb::xkb;
+
+pub(super) struct Notifier {
+    id: usize,
+    sender: channel::Sender<communication::Message>,
+}
+
+impl Notifier {
+    pub(super) const fn new(id: usize, sender: channel::Sender<communication::Message>) -> Self {
+        Self { id, sender }
+    }
+}
+
+impl thread::Runnable for Notifier {
+    fn run(&self) -> Result<()> {
+        // Almost verbatim copy of the code from https://github.com/myfreeweb/unixbar
+        if let Ok((conn, _)) = xcb::Connection::connect(None) {
+            {
+                let cookie = xkb::use_extension(&conn, 1, 0);
+                match cookie.get_reply() {
+                    Ok(r) => {
+                        if !r.supported() {
+                            return Err(Error::new_custom("keymap", "xkb is not supported"));
+                        }
+                    },
+                    Err(_) => return Err(Error::new_custom("keymap", "invalid reply from xkb")),
+                }
+            }
+            {
+                let map_parts = xcb::xkb::MAP_PART_MODIFIER_MAP;
+                let events = xcb::xkb::EVENT_TYPE_STATE_NOTIFY;
+                let cookie = xkb::select_events_checked(
+                    &conn,
+                    xkb::ID_USE_CORE_KBD as u16,
+                    events as u16,
+                    0,
+                    events as u16,
+                    map_parts as u16,
+                    map_parts as u16,
+                    None,
+                );
+                let _ = cookie.request_check();
+            }
+            loop {
+                let event = conn.wait_for_event();
+                match event {
+                    None => {
+                        break Err(Error::new_custom("keymap", "break"));
+                    },
+                    Some(event) => {
+                        let evt: &xkb::StateNotifyEvent = unsafe { xcb::cast_event(&event) };
+                        if evt.changed() as u32 & xcb::xkb::STATE_PART_GROUP_STATE != 0 {
+                            communication::send_message(self.id, &self.sender)?;
+                        }
+                    },
+                }
+            }
+        } else {
+            return Err(Error::new_custom("keymap", "cannot connect to x server"));
+        }
+    }
+}

--- a/src/features/keymap/updater.rs
+++ b/src/features/keymap/updater.rs
@@ -1,0 +1,45 @@
+use super::Data;
+use crate::error::*;
+use crate::feature;
+use xcb;
+use xcb::xkb;
+
+pub(super) struct Updater {
+    data: Data,
+}
+
+impl Updater {
+    pub(super) const fn new(data: Data) -> Self {
+        Self { data }
+    }
+}
+
+impl feature::Updatable for Updater {
+    fn renderable(&self) -> &dyn feature::Renderable {
+        &self.data
+    }
+
+    fn update(&mut self) -> Result<()> {
+        if let Ok((conn, _)) = xcb::Connection::connect(None) {
+            let cookie = xkb::use_extension(&conn, 1, 0);
+            match cookie.get_reply() {
+                Ok(r) => {
+                    if !r.supported() {
+                        return Err(Error::new_custom("keymap", "xkb is not supported"));
+                    }
+                },
+                Err(_) => return Err(Error::new_custom("keymap", "invalid reply from xkb")),
+            }
+            let state = xkb::get_state(&conn, xkb::ID_USE_CORE_KBD as u16);
+            match state.get_reply() {
+                Ok(r) => {
+                    self.data.update(r.group());
+                },
+                Err(_) => return Err(Error::new_custom("keymap", "invalid reply from xkb")),
+            }
+            Ok(())
+        } else {
+            Err(Error::new_custom("keymap", "failed to update keymap state"))
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@
     trivial_casts,
     trivial_numeric_casts,
     unreachable_pub,
-    unsafe_code,
     unused_import_braces,
     unused_qualifications,
     variant_size_differences

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -75,7 +75,7 @@ macro_rules! settings {
     }
 }
 
-settings!(audio, backlight, battery, cpu_load, network, time);
+settings!(audio, backlight, battery, cpu_load, network, time, keymap);
 
 #[cfg(test)]
 #[cfg(feature = "mocking")]


### PR DESCRIPTION
Hello,
Thank you for the nice alternative to slstatus.

I'm learning Rust and decided to implement a feature of slstatus that I miss in dwm-status: displaying the currently select keyboard layout.

The code for listening to Xkb events is almost entirely copied from the menubar project because I'm not really familiar with xcb/xkb bindings, also it's simple and was easy to adapt.

I use this with Emojis for the country flags, but it is possible to use plain strings like "us", "ru", "es", etc.