### PR TITLE
refactor(backlight): support fallback pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,7 @@ dependencies = [
  "config",
  "ctrlc",
  "dbus",
+ "glob",
  "hamcrest2",
  "inotify",
  "libnotify",
@@ -250,6 +251,12 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "gobject-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde = "1.0.136"
 serde_derive = "1.0.136"
 simplelog = "0.12.0"
 uom = { version = "0.30.0", features = ["autoconvert", "f32", "si"] }
+glob = "0.3"
 
 [dependencies.ctrlc]
 features = ["termination"]

--- a/README.md
+++ b/README.md
@@ -80,11 +80,12 @@ Shows status of backlight value and watches `/sys/class/backlight` for changes.
 
 #### Configuration options
 
-| name       | default             | description                                                                  |
-| ---------- | ------------------- | ---------------------------------------------------------------------------- |
-| `device`   | `"intel_backlight"` | Backlight device in `/sys/class/backlight`.                                  |
-| `icons`    | `[]`                | List of icons, which represent different stages relative to the current value, e.g. `["LOW", "MIDDLE, "HIGH"]`.   |
-| `template` | `"L {BL}%"`         | Text representation. (`{BL}` gets replaced with the current backlight value, `{ICO}` gets replaced with the icon) |
+| name       | default             | description                                                                                                                       |
+|------------|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| `device`   | `"intel_backlight"` | Backlight device in `/sys/class/backlight`.                                                                                       |
+| `fallback` | `None`              | If `device` doesn't exist, pattern match (Unix shell style patterns) the first element in `/sys/class/backlight`. e.g. `amdgpu_*` |
+| `icons`    | `[]`                | List of icons, which represent different stages relative to the current value, e.g. `["LOW", "MIDDLE, "HIGH"]`.                   |
+| `template` | `"L {BL}%"`         | Text representation. (`{BL}` gets replaced with the current backlight value, `{ICO}` gets replaced with the icon)                 |
 
 ### Feature: Battery
 

--- a/src/features/backlight.rs
+++ b/src/features/backlight.rs
@@ -24,7 +24,7 @@ pub(super) fn create(
     settings: &ConfigEntry,
 ) -> Result<Box<dyn feature::Feature>> {
     let data = Data::new(settings.render.clone());
-    let device = BacklightDevice::init(&settings.device)?;
+    let device = BacklightDevice::init(settings)?;
 
     Ok(Box::new(feature::Composer::new(
         FEATURE_NAME,

--- a/src/features/backlight/config.rs
+++ b/src/features/backlight/config.rs
@@ -16,6 +16,7 @@ pub(crate) struct RenderConfig {
 #[derive(Clone, Debug, Deserialize)]
 pub(crate) struct ConfigEntry {
     pub(super) device: String,
+    pub(super) fallback: Option<String>,
     #[serde(flatten)]
     pub(super) render: RenderConfig,
 }

--- a/src/features/backlight/device.rs
+++ b/src/features/backlight/device.rs
@@ -1,8 +1,14 @@
+use std::path::Path;
+
 use crate::error::Result;
 use crate::error::WrapErrorExt;
+use crate::features::backlight::ConfigEntry;
 use crate::wrapper::file;
+use glob::glob;
 
 use super::FEATURE_NAME;
+
+const BACKLIGHT_SYS_PATH: &str = "/sys/class/backlight";
 
 pub(super) struct BacklightDevice {
     max: u32,
@@ -10,15 +16,38 @@ pub(super) struct BacklightDevice {
 }
 
 impl BacklightDevice {
-    pub(super) fn init(device: &str) -> Result<Self> {
+    pub(super) fn init(settings: &ConfigEntry) -> Result<Self> {
         let mut device = Self {
             max: 0,
-            path: format!("/sys/class/backlight/{}", device),
+            path: Self::backlight_dir(settings)?,
         };
 
         device.max = device.get_brightness("max")?;
 
         Ok(device)
+    }
+
+    pub(super) fn backlight_dir(settings: &ConfigEntry) -> Result<String> {
+        let default_path = format!("{}/{}", BACKLIGHT_SYS_PATH, settings.device);
+
+        if Path::new(&default_path).exists() || settings.fallback.is_none() {
+            return Ok(default_path);
+        }
+
+        let pattern = format!(
+            "{}/{}",
+            BACKLIGHT_SYS_PATH,
+            settings.fallback.as_ref().unwrap()
+        );
+
+        if let Some(Ok(path)) = glob(&pattern)
+            .wrap_error(FEATURE_NAME, "Failed to read glob pattern")?
+            .next()
+        {
+            return Ok(path.display().to_string());
+        }
+
+        Ok(default_path)
     }
 
     pub(super) fn brightness_file(&self) -> String {


### PR DESCRIPTION
In some scenarios, backlight's device names are dynamic, so a pattern match is required