### PR TITLE
Network: Force dig to use the records corresponding transport

### DIFF
--- a/src/features/network/updater.rs
+++ b/src/features/network/updater.rs
@@ -70,19 +70,20 @@ fn essid() -> Option<String> {
 }
 
 fn ip_address(address_type: &IpAddress) -> Option<String> {
-    let command = process::Command::new("dig", &[
+    let mut command = process::Command::new("dig", &[
         // decrease time and tries because commands are executed synchronously
         // TODO: make asychronous
         "+time=3",  // default: 5 seconds
         "+tries=1", // default: 3
         "@resolver1.opendns.com",
-        match address_type {
-            IpAddress::V4 => "A",
-            IpAddress::V6 => "AAAA",
-        },
         "myip.opendns.com",
         "+short",
     ]);
+
+    command.args(match address_type {
+        IpAddress::V4 => ["A", "-4"],
+        IpAddress::V6 => ["AAAA", "-6"],
+    });
 
     let output = command.output().wrap_error(
         FEATURE_NAME,

--- a/src/wrapper/process.rs
+++ b/src/wrapper/process.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::io::Read;
 use std::process;
 
@@ -13,7 +14,10 @@ pub(crate) struct Command {
 }
 
 impl Command {
-    pub(crate) fn new(program: &str, args: &[&str]) -> Self {
+    pub(crate) fn new<S>(program: &str, args: &[S]) -> Self
+    where
+        S: AsRef<OsStr>,
+    {
         let mut command = process::Command::new(program);
         for arg in args {
             command.arg(arg);

--- a/src/wrapper/process.rs
+++ b/src/wrapper/process.rs
@@ -26,6 +26,14 @@ impl Command {
         Self { command }
     }
 
+    pub(crate) fn args<I, S>(&mut self, args: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        self.command.args(args);
+    }
+
     pub(crate) fn output(mut self) -> Result<String> {
         self.command
             .output()


### PR DESCRIPTION
Using these `-4` and `-6` options, we force dig to do `@nameserver` look-ups via the corresponding transport, meaning `resolver1.opendns.com` responds to us nicely again, yay :3

Resolves #175