### PR TITLE
Add possibility to add CPU as Percentage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ simplelog = "0.12.2"
 uom = { version = "0.30.0", features = ["autoconvert", "f32", "si"] }
 glob = "0.3.3"
 serde_json = "1.0.145"
+regex = "1.11.3"
+evalexpr = "12.0.2"
 
 [dependencies.ctrlc]
 features = ["termination"]

--- a/README.md
+++ b/README.md
@@ -132,8 +132,10 @@ Shows CPU load taken from `/proc/loadavg` in configured format and refreshes eve
 
 | name              | default                | description                 |
 | ----------------- | ---------------------- | --------------------------- |
-| `template`        | `"{CL1} {CL5} {CL15}"` | Text representation. (`{CLx}` gets replaced with the load of last `x` minutes for `x` in `{1, 5, 15}`) |
+| `template`        | `"{CL1} {CL5} {CL15}"` | Text representation. (`{CLx}` gets replaced with the load of last `x` minutes for `x` in `{1, 5, 15}`), `{NPROC}` shows the number of processors. |
 | `update_interval` | `20`                   | Update interval in seconds. |
+
+You can also do math allowing for templates like `"{CL1/NPROC*100}%` to display the load of the last minute in percent.
 
 ### Feature: Network
 

--- a/src/expression_parser.rs
+++ b/src/expression_parser.rs
@@ -1,0 +1,72 @@
+use regex::Regex;
+use regex::Captures;
+use evalexpr::*;
+
+pub(crate) fn evaluate_expression(template: &str, vars: &HashMapContext<DefaultNumericTypes>) -> String {
+    let re = Regex::new(r"\{([^}]+)\}").unwrap();
+
+    return re.replace_all(template, |caps: &Captures<'_>| {
+        let expr = &caps[1];
+        match eval_with_context(expr, vars) {
+            Ok(Value::Float(f)) => format!("{:.2}", f),
+            Ok(s) => s.to_string(),
+            Err(_) => format!("{{{}}}", expr),
+        }
+    }).into_owned();
+
+}
+
+#[cfg(test)]
+mod tests {
+    use hamcrest2::assert_that;
+    use hamcrest2::prelude::*;
+
+    use super::*;
+
+    fn get_test_vars() -> HashMapContext<DefaultNumericTypes> {
+        let context : HashMapContext<DefaultNumericTypes> = context_map! {
+            "A" => Value::from_float(0.2),
+            "B" => Value::from_float(0.4),
+            "C" => Value::from_int(4),
+        }.unwrap();
+
+        context
+    }
+
+    #[test]
+    fn evaluate_empty() {
+        let vars = get_test_vars();
+
+        let evaluated = evaluate_expression("", &vars);
+
+        assert_that!(evaluated, is(equal_to("")));
+    }
+
+    #[test]
+    fn evaluate_replace_simple() {
+
+        let vars = get_test_vars();
+
+        let evaluated = evaluate_expression("{A} {C} {A} test", &vars);
+
+        assert_that!(evaluated, is(equal_to("0.20 4 0.20 test")));
+    }
+
+    #[test]
+    fn evaluate_division() {
+        let vars = get_test_vars();
+
+        let evaluated = evaluate_expression("{B/C}", &vars);
+
+        assert_that!(evaluated, is(equal_to("0.10")));
+    }
+
+    #[test]
+    fn evaluate_percentage() {
+        let vars = get_test_vars();
+
+        let evaluated = evaluate_expression("{B/C*100}%", &vars);
+
+        assert_that!(evaluated, is(equal_to("10.00%")));
+    }
+}

--- a/src/expression_parser.rs
+++ b/src/expression_parser.rs
@@ -65,8 +65,8 @@ mod tests {
     fn evaluate_percentage() {
         let vars = get_test_vars();
 
-        let evaluated = evaluate_expression("{B/C*100}%", &vars);
+        let evaluated = evaluate_expression("{B/C*100}% {A}", &vars);
 
-        assert_that!(evaluated, is(equal_to("10.00%")));
+        assert_that!(evaluated, is(equal_to("10.00% 0.20")));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ mod features;
 mod resume;
 mod settings;
 mod status_bar;
+mod expression_parser;
 #[cfg(test)]
 mod test_utils;
 mod utils;


### PR DESCRIPTION
I've added an expression parser that can do math inside of the curly brackets at least in the cpu_load right now
I've also added the reading of the number of processors.
In combination this allows to calculate the load average as percentage like I added in the README